### PR TITLE
add date-fns dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "node": ">=16.0.0"
   },
   "dependencies": {
+    "date-fns": "^3.6.0",
     "ts-error-as-value": "^0.4.207",
     "uuid": "^9.0.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2031,6 +2031,11 @@ date-fns@*:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-3.3.1.tgz#7581daca0892d139736697717a168afbb908cfed"
   integrity sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==
 
+date-fns@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-3.6.0.tgz#f20ca4fe94f8b754951b24240676e8618c0206bf"
+  integrity sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==
+
 debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"


### PR DESCRIPTION
This should resolve the following error when attempting to reference the package:
`error: Cannot find package "date-fns" from ".../node_modules/qbo/dist/lib/utils.js"`

The current output of `yarn why date-fns` shows:
```
=> Found "date-fns@3.3.1"
info Reasons this module exists
   - "@types#date-fns" depends on it
   - Hoisted from "@types#date-fns#date-fns"
info Disk size without dependencies: "19.07MB"
info Disk size with unique dependencies: "19.07MB"
info Disk size with transitive dependencies: "19.07MB"
info Number of shared dependencies: 0
```

[But `date-fns` is used directly in a few src files](https://github.com/search?q=repo%3AWith-The-Ranks%2Fqbo%20date-fns&type=code)

So using it as a regular dependency should make sure it's installed wherever the `qbo` package is installed